### PR TITLE
Add missing interface definitions dealing with delivered notifications

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -12,6 +12,7 @@ import android.os.Bundle;
 import com.dieam.reactnativepushnotification.helpers.ApplicationBadgeHelper;
 import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
@@ -197,5 +198,31 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
     @ReactMethod
     public void registerNotificationActions(ReadableArray actions) {
         registerNotificationsReceiveNotificationActions(actions);
+    }
+
+    @ReactMethod
+    /**
+     * Clears all notifications from the notification center
+     *
+     */
+    public void removeAllDeliveredNotifications() {
+      mRNPushNotificationHelper.clearNotifications();
+    }
+
+    @ReactMethod
+    /**
+     * Returns a list of all notifications currently in the Notification Center
+     */
+    public void getDeliveredNotifications(Callback callback) {
+      callback.invoke(mRNPushNotificationHelper.getDeliveredNotifications());
+    }
+
+    @ReactMethod
+    /**
+     * Removes notifications from the Notification Center, whose id matches
+     * an element in the provided array
+     */
+    public void removeDeliveredNotifications(ReadableArray identifiers) {
+      mRNPushNotificationHelper.clearDeliveredNotifications(identifiers);
     }
 }

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -425,6 +425,11 @@ public class RNPushNotificationHelper {
       StatusBarNotification delivered[] = notificationManager.getActiveNotifications();
       Log.i(LOG_TAG, "Found " + delivered.length + " delivered notifications");
       WritableArray result = Arguments.createArray();
+      /*
+        * stay consistent to the return structure in
+        * https://facebook.github.io/react-native/docs/pushnotificationios.html#getdeliverednotifications
+        * but there is no such thing as a 'userInfo'
+        */
       for (StatusBarNotification notification : delivered) {
         Notification original = notification.getNotification();
         Bundle extras = original.extras;

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -18,10 +18,15 @@ import android.media.RingtoneManager;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.service.notification.StatusBarNotification;
 import android.support.v4.app.NotificationCompat;
 import android.util.Log;
 
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.bridge.WritableMap;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -406,6 +411,35 @@ public class RNPushNotificationHelper {
         notificationManager.cancelAll();
     }
 
+    public void clearDeliveredNotifications(ReadableArray identifiers) {
+      NotificationManager notificationManager = notificationManager();
+      for (int index = 0; index < identifiers.size(); index++) {
+        String id = identifiers.getString(index);
+        Log.i(LOG_TAG, "Removing notification with id " + id);
+        notificationManager.cancel(Integer.parseInt(id));
+      }
+    }
+
+    public WritableArray getDeliveredNotifications() {
+      NotificationManager notificationManager = notificationManager();
+      StatusBarNotification delivered[] = notificationManager.getActiveNotifications();
+      Log.i(LOG_TAG, "Found " + delivered.length + " delivered notifications");
+      WritableArray result = Arguments.createArray();
+      for (StatusBarNotification notification : delivered) {
+        Notification original = notification.getNotification();
+        Bundle extras = original.extras;
+        WritableMap notif = Arguments.createMap();
+        notif.putString("identifier", "" + notification.getId());
+        notif.putString("title", extras.getString(Notification.EXTRA_TITLE));
+        notif.putString("body", extras.getString(Notification.EXTRA_TEXT));
+        notif.putString("tag", notification.getTag());
+        notif.putString("group", original.getGroup());
+        result.pushMap(notif);
+      }
+
+      return result;
+
+    }
     public void cancelAllScheduledNotifications() {
         Log.i(LOG_TAG, "Cancelling all notifications");
 

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationListenerService.java
@@ -29,7 +29,7 @@ public class RNPushNotificationListenerService extends GcmListenerService {
         JSONObject data = getPushData(bundle.getString("data"));
         if (data != null) {
             if (!bundle.containsKey("message")) {
-                bundle.putString("message", data.optString("alert", "Notification received"));
+                bundle.putString("message", data.optString("alert", null));
             }
             if (!bundle.containsKey("title")) {
                 bundle.putString("title", data.optString("title", null));

--- a/component/index.android.js
+++ b/component/index.android.js
@@ -108,6 +108,17 @@ NotificationsComponent.prototype.clearAllNotifications = function() {
 	RNPushNotification.clearAllNotifications()
 }
 
+NotificationsComponent.prototype.removeAllDeliveredNotifications = function() {
+  RNPushNotification.removeAllDeliveredNotifications();
+}
+
+NotificationsComponent.prototype.getDeliveredNotifications = function(callback: Function) {
+  RNPushNotification.getDeliveredNotifications(callback);
+}
+NotificationsComponent.prototype.removeDeliveredNotifications = function(identifiers: Array) {
+  RNPushNotification.removeDeliveredNotifications(identifiers);
+}
+
 module.exports = {
 	state: false,
 	component: new NotificationsComponent()

--- a/index.js
+++ b/index.js
@@ -321,4 +321,16 @@ Notifications.clearAllNotifications = function() {
 	return this.callNative('clearAllNotifications', arguments)
 }
 
+Notifications.removeAllDeliveredNotifications = function() {
+	return this.callNative('removeAllDeliveredNotifications', arguments);
+}
+
+Notifications.getDeliveredNotifications = function() {
+	return this.callNative('getDeliveredNotifications', arguments);
+}
+
+Notifications.removeDeliveredNotifications = function() {
+	return this.callNative('removeDeliveredNotifications', arguments);
+}
+
 module.exports = Notifications;


### PR DESCRIPTION
on iOS will continue to pass through to PushNotificationIOS, but android will leverage NotificationManager to retrieve and cancel relevant notifications.

Some useful reference/background material:

- PushNotificationIOS: https://facebook.github.io/react-native/docs/pushnotificationios.html
     React-Native has a class that works well for push on iOS, but provides nothing on Android.  There were a few interfaces defined there that we need

- Building Native modules on Android: https://facebook.github.io/react-native/docs/native-modules-android.html
     Describes semantics required to bridge methods and modules for Java <-> Javascript interactions.

- Marshaling types: https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/bridge
      The React-Native bridge defines data types for marshaling bidirectionally between Java and Javascript.  

- Android NotificationManager: https://developer.android.com/reference/android/app/NotificationManager.html

- StatusBarNotification: https://developer.android.com/reference/android/service/notification/StatusBarNotification.html
